### PR TITLE
Use forwarded headers to support reverse proxy

### DIFF
--- a/PQDigest/Startup.cs
+++ b/PQDigest/Startup.cs
@@ -21,29 +21,26 @@
 //
 //******************************************************************************************************
 
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text.RegularExpressions;
+using Gemstone.Data;
+using Gemstone.Web;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Gemstone.Web;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc.Authorization;
-using Newtonsoft.Json.Serialization;
 using Microsoft.Identity.Web;
-using Microsoft.IdentityModel.Protocols.OpenIdConnect;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.Graph;
-using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.Identity.Web.UI;
-using System.Net.Http.Headers;
-using System.Security.Claims;
-using Newtonsoft.Json;
-using System.Net.Http;
 using Newtonsoft.Json.Linq;
-using System.Linq;
-using System.Text.RegularExpressions;
-using Gemstone.Data;
+using Newtonsoft.Json.Serialization;
 
 namespace PQDigest
 {
@@ -118,8 +115,8 @@ namespace PQDigest
                })
               .EnableTokenAcquisitionToCallDownstreamApi(options =>
                 {
-                      Configuration.Bind("AzureAd", options);
-                },Configuration.GetSection("GraphAPI")["Scopes"].Split(",")
+                    Configuration.Bind("AzureAd", options);
+                }, Configuration.GetSection("GraphAPI")["Scopes"].Split(",")
              )
             .AddInMemoryTokenCaches();
 
@@ -144,19 +141,20 @@ namespace PQDigest
                 app.UseExceptionHandler("/Error");
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
-
             }
 
-            
+            app.UseForwardedHeaders(new ForwardedHeadersOptions()
+            {
+                ForwardedHeaders = ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost
+            });
+
             app.UseStaticFiles(WebExtensions.StaticFileEmbeddedResources());
             app.UseStaticFiles();
 
             app.UseRouting();
 
-
             app.UseAuthentication();
             app.UseAuthorization();
-
 
             app.UseEndpoints(endpoints =>
             {
@@ -170,7 +168,6 @@ namespace PQDigest
 
                 endpoints.MapControllers();
             });
-
         }
 
         public static void AddUserGraphInfo(ClaimsPrincipal claimsPrincipal, string json)


### PR DESCRIPTION
Microsoft.Identity.Web will use the scheme and host from the request alongside the `CallbackPath` from `AzureAD` settings to build the redirect URI. This PR enables the middleware that copies information from the `X-Forwarded-*` request headers to the request properties so that PQ Digest can effectively be made aware of the reverse proxy when building the redirect URI.

I've read that best practice is to populate the `ForwardedHeadersOptions.KnownNetworks` and `ForwardedHeadersOptions.KnownProxies` collections to whitelist the reverse proxy. However, Azure already whitelists the redirect URI for us so I don't know how a MITM could be exploited in the case of PQ Digest. For that reason, I think it's better to keep this simple for now.