### PR TITLE
Add Ability to Read from Environment Variables

### DIFF
--- a/PQDigest/Program.cs
+++ b/PQDigest/Program.cs
@@ -1,7 +1,7 @@
 //******************************************************************************************************
 //  Program.cs - Gbtc
 //
-//  Copyright © 2020, Grid Protection Alliance.  All Rights Reserved.
+//  Copyright ï¿½ 2020, Grid Protection Alliance.  All Rights Reserved.
 //
 //  Licensed to the Grid Protection Alliance (GPA) under one or more contributor license agreements. See
 //  the NOTICE file distributed with this work for additional information regarding copyright ownership.
@@ -58,7 +58,8 @@ namespace PQDigest
                 Settings settings = new()
                 {
                     INIFile = ConfigurationOperation.ReadWrite,
-                    SQLite = ConfigurationOperation.Disabled
+                    SQLite = ConfigurationOperation.Disabled,
+                    EnvironmentalVariables = ConfigurationOperation.ReadOnly
                 };
 
                 DefineSettings(settings);


### PR DESCRIPTION
This change allows for Gemstone to receive configuration via environment variables.
Example to set ADO Connection String:
```GEMSTONE_System__ConnectionString=abcdefg1234567```