### PR TITLE
Libraries: Reference gemstone development projects when in Debug mode

### DIFF
--- a/Libraries/FaultAlgorithms/FaultAlgorithms.csproj
+++ b/Libraries/FaultAlgorithms/FaultAlgorithms.csproj
@@ -8,8 +8,8 @@
   <ItemGroup>
     <PackageReference
       Include="Gemstone.Numeric"
-      Version="1.0.157"
       Condition="'$(Configuration)'!='Debug'"
+      Version="1.0.165"
     />
     <ProjectReference
       Include="..\..\..\gemstone\numeric\src\Gemstone.Numeric\Gemstone.Numeric.csproj"

--- a/Libraries/FaultAlgorithms/FaultAlgorithms.csproj
+++ b/Libraries/FaultAlgorithms/FaultAlgorithms.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -7,7 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Gemstone.Numeric" Version="1.0.157" />
+    <PackageReference
+      Include="Gemstone.Numeric"
+      Version="1.0.157"
+      Condition="'$(Configuration)'!='Debug'"
+    />
+    <ProjectReference
+      Include="..\..\..\gemstone\numeric\src\Gemstone.Numeric\Gemstone.Numeric.csproj"
+      Condition="'$(Configuration)'=='Debug'"
+    />
   </ItemGroup>
-
 </Project>

--- a/Libraries/FaultData/FaultData.csproj
+++ b/Libraries/FaultData/FaultData.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -7,13 +6,29 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Gemstone.Data" Version="1.0.157" />
-    <PackageReference Include="Gemstone.PQDIF" Version="1.0.157" />
+    <PackageReference
+      Include="Gemstone.Data"
+      Version="1.0.157"
+      Condition="'$(Configuration)'!='Debug'"
+    />
+    <PackageReference
+      Include="Gemstone.PQDIF"
+      Version="1.0.157"
+      Condition="'$(Configuration)'!='Debug'"
+    />
+
+    <ProjectReference
+      Include="..\..\..\gemstone\data\src\Gemstone.Data\Gemstone.Data.csproj"
+      Condition="'$(Configuration)'=='Debug'"
+    />
+    <ProjectReference
+      Include="..\..\..\gemstone\pqdif\src\Gemstone.PQDif\Gemstone.PQDif.csproj"
+      Condition="'$(Configuration)'=='Debug'"
+    />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\FaultAlgorithms\FaultAlgorithms.csproj" />
     <ProjectReference Include="..\openXDA.Model\openXDA.Model.csproj" />
   </ItemGroup>
-
 </Project>

--- a/Libraries/FaultData/FaultData.csproj
+++ b/Libraries/FaultData/FaultData.csproj
@@ -8,13 +8,13 @@
   <ItemGroup>
     <PackageReference
       Include="Gemstone.Data"
-      Version="1.0.157"
       Condition="'$(Configuration)'!='Debug'"
+      Version="1.0.165"
     />
     <PackageReference
       Include="Gemstone.PQDIF"
-      Version="1.0.157"
       Condition="'$(Configuration)'!='Debug'"
+      Version="1.0.165"
     />
 
     <ProjectReference

--- a/Libraries/openXDA.Model/openXDA.Model.csproj
+++ b/Libraries/openXDA.Model/openXDA.Model.csproj
@@ -8,18 +8,18 @@
   <ItemGroup>
     <PackageReference
       Include="Gemstone.Data"
-      Version="1.0.157"
       Condition="'$(Configuration)'!='Debug'"
+      Version="1.0.165"
     />
     <PackageReference
       Include="Gemstone.IO"
-      Version="1.0.157"
       Condition="'$(Configuration)'!='Debug'"
+      Version="1.0.165"
     />
     <PackageReference
       Include="Gemstone.PQDIF"
-      Version="1.0.157"
       Condition="'$(Configuration)'!='Debug'"
+      Version="1.0.165"
     />
     <ProjectReference
       Include="..\..\..\gemstone\data\src\Gemstone.Data\Gemstone.Data.csproj"

--- a/Libraries/openXDA.Model/openXDA.Model.csproj
+++ b/Libraries/openXDA.Model/openXDA.Model.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -7,9 +6,32 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Gemstone.Data" Version="1.0.157" />
-    <PackageReference Include="Gemstone.IO" Version="1.0.157" />
-    <PackageReference Include="Gemstone.PQDIF" Version="1.0.157" />
+    <PackageReference
+      Include="Gemstone.Data"
+      Version="1.0.157"
+      Condition="'$(Configuration)'!='Debug'"
+    />
+    <PackageReference
+      Include="Gemstone.IO"
+      Version="1.0.157"
+      Condition="'$(Configuration)'!='Debug'"
+    />
+    <PackageReference
+      Include="Gemstone.PQDIF"
+      Version="1.0.157"
+      Condition="'$(Configuration)'!='Debug'"
+    />
+    <ProjectReference
+      Include="..\..\..\gemstone\data\src\Gemstone.Data\Gemstone.Data.csproj"
+      Condition="'$(Configuration)'=='Debug'"
+    />
+    <ProjectReference
+      Include="..\..\..\gemstone\io\src\Gemstone.IO\Gemstone.IO.csproj"
+      Condition="'$(Configuration)'=='Debug'"
+    />
+    <ProjectReference
+      Include="..\..\..\gemstone\pqdif\src\Gemstone.PQDif\Gemstone.PQDif.csproj"
+      Condition="'$(Configuration)'=='Debug'"
+    />
   </ItemGroup>
-
 </Project>

--- a/PQDigest/PQDigest-dev.slnx
+++ b/PQDigest/PQDigest-dev.slnx
@@ -38,6 +38,9 @@
       <Project Path="../../gemstone/web/src/Gemstone.Web/Gemstone.Web.csproj">
         <BuildType Solution="Debug|*" Project="Development" />
       </Project>
+      <Project Path="../../gemstone/io/src/Gemstone.IO/Gemstone.IO.csproj">
+        <BuildType Solution="Debug|*" Project="Development" />
+      </Project>
     </Folder>
   <Project Path="PQDigest.csproj" />
 </Solution>

--- a/PQDigest/PQDigest.csproj
+++ b/PQDigest/PQDigest.csproj
@@ -35,11 +35,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Gemstone.Common" Version="1.0.157" Condition="'$(Configuration)'!='Debug'" />
-    <PackageReference Include="Gemstone.Data" Version="1.0.157" Condition="'$(Configuration)'!='Debug'" />
-    <PackageReference Include="Gemstone.Numeric" Version="1.0.157" Condition="'$(Configuration)'!='Debug'" />
-    <PackageReference Include="Gemstone.PQDIF" Version="1.0.157" Condition="'$(Configuration)'!='Debug'" />
-    <PackageReference Include="Gemstone.Web" Version="1.0.157" Condition="'$(Configuration)'!='Debug'" />
+    <PackageReference Include="Gemstone.Common" Version="1.0.165" Condition="'$(Configuration)'!='Debug'" />
+    <PackageReference Include="Gemstone.Data" Version="1.0.165" Condition="'$(Configuration)'!='Debug'" />
+    <PackageReference Include="Gemstone.Numeric" Version="1.0.165" Condition="'$(Configuration)'!='Debug'" />
+    <PackageReference Include="Gemstone.PQDIF" Version="1.0.165" Condition="'$(Configuration)'!='Debug'" />
+    <PackageReference Include="Gemstone.Web" Version="1.0.165" Condition="'$(Configuration)'!='Debug'" />
 	  <ProjectReference Include="..\..\gemstone\web\src\Gemstone.Web\Gemstone.Web.csproj" Condition="'$(Configuration)'=='Debug'" />
     <ProjectReference Include="..\..\gemstone\common\src\Gemstone\Gemstone.Common.csproj" Condition="'$(Configuration)'=='Debug'" />
     <ProjectReference Include="..\..\gemstone\data\src\Gemstone.Data\Gemstone.Data.csproj" Condition="'$(Configuration)'=='Debug'" />


### PR DESCRIPTION
I have updated the library *csproj files to reference the local gemstone projects when in Debug mode. This was done to make the linking behavior consistent with the primary PQDigest.csproj project.

This change was made to debug portions of the Gemstone library without having to rely on decompiled code.